### PR TITLE
When removing a spatial cond, unselect only already selected features

### DIFF
--- a/lib/Styler/widgets/SpatialFilterPanel.js
+++ b/lib/Styler/widgets/SpatialFilterPanel.js
@@ -121,7 +121,10 @@ Styler.SpatialFilterPanel = Ext.extend(Styler.BaseFilterPanel, {
      * {Boolean} By default, true to enable panel removal.
      */
     tearDown: function() {
-        this.mfControl.unselectFeature(this.feature);
+        if (this.feature.renderIntent &&
+            this.feature.renderIntent == 'select') {
+            this.mfControl.unselectFeature(this.feature);
+        }
         this.feature.layer.destroyFeatures([this.feature]);
         return true;
     },


### PR DESCRIPTION
As for now when one tries to remove a spatial condition from a filter panel, a javascript error is issued:
`Uncaught TypeError: Cannot read property 'style' of null` at https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Layer/Vector.js#L799
unless the "edit" button is toggle on (ie the drawn feature is selected).

This PR suggests to test if the feature to remove is actually selected before trying to unselect it.
