### PR TITLE
toolbar location

### DIFF
--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -106,6 +106,13 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
     deactivable: false,
 
     /**
+     * Property: toolbarType
+     * {String} Place toolbar at the bottom with 'bbar' or
+     *  at the 'top' with 'tbar'
+     */
+    toolbarType: 'bbar',
+
+    /**
      * Property: noConditionOnInit
      * {Boolean}
      */
@@ -169,7 +176,8 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
             }, this.createChildFiltersPanel()
         ];
 
-        this.bbar = this.createToolBar();
+        this[this.toolbarType] = this.createToolBar();
+
         this.addEvents(
             /**
              * Event: change


### PR DESCRIPTION
We add the toolbarType property to FilterBuilder widget. Toolbar can be placed at top or at the bottom of the panel according to this property.