### PR TITLE
Buffer in spatial filter panel

### DIFF
--- a/lib/Styler/lang/de.js
+++ b/lib/Styler/lang/de.js
@@ -10,6 +10,8 @@ OpenLayers.Lang.de = OpenLayers.Util.extend(OpenLayers.Lang.de, {
     "This field is mandatory": "Pflichtfeld",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Geometrie ändern",
+    "Edit geometrie": "Edit geometrie (de)",
+    "Create buffer": "Create buffer (de)",
     "Save this geometry": "Diese Geometrie speichern",
     "spatialfilterpanel.geometry.saved": "Geometrie auf dem Navigator gespeichert.",
     /* FilterBuilder.js */

--- a/lib/Styler/lang/es.js
+++ b/lib/Styler/lang/es.js
@@ -10,7 +10,9 @@ OpenLayers.Lang.es = OpenLayers.Util.extend(OpenLayers.Lang.es, {
     "This field is mandatory": "Este campo es requerido",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Modificar la geometría",
+    "Edit geometrie": "Edit geometrie (es)",
     "Save this geometry": "Grabar la geometría",
+    "Create buffer": "Create buffer (es)",
     "spatialfilterpanel.geometry.saved": "Geometría grabada en este navegador.",
     /* FilterBuilder.js */
     "any": "una de",

--- a/lib/Styler/lang/fr.js
+++ b/lib/Styler/lang/fr.js
@@ -10,6 +10,8 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
     "This field is mandatory": "Ce champ est nécessaire",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Modifier la géométrie",
+    "Edit geometrie": "Éditer la géométrie",
+    "Create buffer": "Créer une zone tampon",
     "Save this geometry": "Enregistrer cette géométrie",
     "spatialfilterpanel.geometry.saved": "Géométrie enregistrée sur ce navigateur.",
     /* FilterBuilder.js */

--- a/lib/Styler/lang/ru.js
+++ b/lib/Styler/lang/ru.js
@@ -10,7 +10,9 @@ OpenLayers.Lang.ru = OpenLayers.Util.extend(OpenLayers.Lang.ru, {
     "This field is mandatory": "Это поле является обязательным",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Изменить геометрию",
+    "Edit geometrie": "Edit geometrie (ru)",
     "Save this geometry": "Сохранить эту геометрию",
+    "Create buffer": "Create buffer (ru)",
     "spatialfilterpanel.geometry.saved": "Геометрия будет сохранена на этом навигаторе",
     /* FilterBuilder.js */
     "any": "какой-нибудь из",

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -106,6 +106,11 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
     deactivable: false,
 
     /**
+     * Property: bufferSupport
+     */
+    bufferSupport: false,
+
+    /**
      * Property: toolbarType
      * {String} Place toolbar at the bottom with 'bbar' or
      *  at the 'top' with 'tbar'
@@ -678,6 +683,7 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
         var filter, type;
 
         var cfg = {
+            filterbuilder: this,
             customizeFilterOnInit: (conditionType === "group") && false,
             listeners: {
                 "change": function() {

--- a/lib/Styler/widgets/SpatialFilterPanel.js
+++ b/lib/Styler/widgets/SpatialFilterPanel.js
@@ -143,41 +143,132 @@ Styler.SpatialFilterPanel = Ext.extend(Styler.BaseFilterPanel, {
 
         var buttonPanels = [{
             items: [{
-                xtype: "button",
+                xtype: "splitbutton",
                 iconCls: cls,
                 tooltip: OpenLayers.i18n("Modify geometry"),
                 enableToggle: true,
                 toggleGroup: this.toggleGroup,
-                listeners: {
-                    "toggle": function(btn, pressed) {
-                        var feature = this.feature;
-                        if (pressed) {
-                            var geometry = feature.geometry;
-                            if (geometry.CLASS_NAME === "OpenLayers.Geometry.Point") {
-                                this.map.setCenter(
-                                    geometry.getBounds().getCenterLonLat()
-                                );
-                            } else {
-                                this.map.zoomToExtent(
-                                    geometry.getBounds().scale(1.05)
-                                );
+                menu: {
+                    xtype: "menu",
+                    listeners: {
+                        "beforehide" : function() {
+                            var combo = this.findByType('combo')[0];
+                            if (combo) {
+                                return !(combo.view && combo.view.isVisible());
                             }
-                            // zindex hack (might need a rework of the handler feature 's
-                            // moveLayerToTop and moveLayerBack methods to manage this)
-                            zindex = feature.layer.getZIndex();
-                            this.mfControl.activate();
-                            this.mfControl.selectFeature(feature);
-                            feature.layer.setZIndex(this.map.Z_INDEX_BASE.Feature+1);
-                        } else {
-                            this.mfControl.unselectFeature(feature);
-                            this.mfControl.deactivate();
-                            feature.layer.setZIndex(zindex);
                         }
                     },
-                    scope: this
+                    items: [
+                        {
+                            xtype: "panel",
+                            border: false,
+                            bodyStyle : 'background:none',
+                            items:
+                           {
+                               xtype: "button",
+                               iconCls: cls,
+                               tooltip: OpenLayers.i18n("Edit geometry"),
+                               enableToggle: true,
+                               allowDepress: true,
+                               toggleGroup: this.toggleGroup,
+                               listeners: {
+                                   "toggle": function(btn, pressed) {
+                                       var feature = this.feature;
+                                       if (pressed) {
+                                           var geometry = feature.geometry;
+                                           if (geometry.CLASS_NAME === "OpenLayers.Geometry.Point") {
+                                               this.map.setCenter(
+                                                   geometry.getBounds().getCenterLonLat()
+                                               );
+                                           } else {
+                                               this.map.zoomToExtent(
+                                                   geometry.getBounds().scale(1.05)
+                                               );
+                                           }
+                                           // zindex hack (might need a rework of the handler feature 's
+                                           // moveLayerToTop and moveLayerBack methods to manage this)
+                                           zindex = feature.layer.getZIndex();
+                                           this.mfControl.activate();
+                                           this.mfControl.selectFeature(feature);
+                                           feature.layer.setZIndex(this.map.Z_INDEX_BASE.Feature+1);
+                                       } else {
+                                           this.mfControl.unselectFeature(feature);
+                                           this.mfControl.deactivate();
+                                           feature.layer.setZIndex(zindex);
+                                       }
+                                   },
+                                   scope: this
+                               }
+                           }
+                        }
+                    ]
                 }
             }]
         }];
+        if (this.filterbuilder.bufferSupport) {
+            var clickListener = function(btn) {
+                var feature = btn.findParentByType('gx_spatialfilterpanel').feature,
+                    bufferFeature = feature.clone();
+                var wkt = new OpenLayers.Format.WKT(),
+                    json = new OpenLayers.Format.JSON();
+                OpenLayers.Request.POST({
+                    url: GEOR.config.PATHNAME + "/ws/buffer/" +
+                          btn.findParentByType("panel").findByType("combo")[0].getValue(),
+                    data: wkt.extractGeometry(feature.geometry),
+                    success: function(response) {
+                        var bWkt = json.read(response.responseText)['geometry'];
+                        bufferFeature.geometry = wkt.read(bWkt).geometry;
+                        feature.layer.addFeatures([bufferFeature]);
+                    },
+                    scope: this
+                });
+                btn.findParentByType('menu').hide();
+                btn.toggle();
+            }
+
+            var bufferPanel = {
+                xtype: "panel",
+                border: false,
+                bodyStyle : 'background:none',
+                layout: "hbox",
+                width: 162,
+                items:
+                    [{
+                        xtype: "button",
+                        iconCls: "add",
+                        tooltip: OpenLayers.i18n("Create buffer"),
+                        enableToggle: false,
+                        toggleGroup: this.toggleGroup,
+                        listeners: {
+                            "click": clickListener
+                        }
+                    },
+                    {
+                        xtype: "combo",
+                        width: 140,
+                        typeAhead: true,
+                        triggerAction: 'all',
+                        autoSelect: true,
+                        emptyText: "Buffer size in meter",
+                        mode: 'local',
+                        store: {
+                            xtype: "arraystore",
+                            id: 0,
+                            fields: [
+                                'bufferSize',
+                                'displayText'
+                            ],
+                            data: [[10, '10 m'], [100, '100 m'], 
+                                [1000, '1 km'],[10000, '10 km']]
+                        },
+                        valueField: 'bufferSize',
+                        displayField: 'displayText'
+                    }
+                ]
+            };
+            var splitButton = buttonPanels[0].items[0];
+            splitButton.menu.items.push(bufferPanel);
+        }
 
         if (this.cookieProvider && OpenLayers.Format && OpenLayers.Format.WKT) {
             buttonPanels.push({
@@ -214,7 +305,7 @@ Styler.SpatialFilterPanel = Ext.extend(Styler.BaseFilterPanel, {
                     items: [this.comboConfig]
                 }]
             }, {
-                width: 70,
+                width: 90,
                 layout: 'column',
                 defaults: {
                     border: false,


### PR DESCRIPTION
We can add a buffer to an existing geometry to create a new filter.

![capture_requeteur_tampon](https://cloud.githubusercontent.com/assets/973241/14025749/f6cce832-f1c5-11e5-94f2-e9b0c841848d.png)

FilterBuilder now have the bufferSupport parameter (false by default).

A split button allows to choose between editing the geometry or creating a buffer.

Some buffer distances are suggested in the combobox. User can also sets a distance in meter.

The buffer operation is made on the mapfishapp server side.
