### PR TITLE
Filters can be saved and loaded to/from XML files

### DIFF
--- a/lib/Styler/lang/de.js
+++ b/lib/Styler/lang/de.js
@@ -10,6 +10,8 @@ OpenLayers.Lang.de = OpenLayers.Util.extend(OpenLayers.Lang.de, {
     "This field is mandatory": "Pflichtfeld",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Geometrie ändern",
+    "Edit geometrie": "Edit geometrie (de)",
+    "Create buffer": "Create buffer (de)",
     "Save this geometry": "Diese Geometrie speichern",
     "spatialfilterpanel.geometry.saved": "Geometrie auf dem Navigator gespeichert.",
     /* FilterBuilder.js */

--- a/lib/Styler/lang/es.js
+++ b/lib/Styler/lang/es.js
@@ -10,7 +10,9 @@ OpenLayers.Lang.es = OpenLayers.Util.extend(OpenLayers.Lang.es, {
     "This field is mandatory": "Este campo es requerido",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Modificar la geometría",
+    "Edit geometrie": "Edit geometrie (es)",
     "Save this geometry": "Grabar la geometría",
+    "Create buffer": "Create buffer (es)",
     "spatialfilterpanel.geometry.saved": "Geometría grabada en este navegador.",
     /* FilterBuilder.js */
     "any": "una de",

--- a/lib/Styler/lang/fr.js
+++ b/lib/Styler/lang/fr.js
@@ -8,6 +8,9 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
     "contains": "contient l'objet",
     /* FilterPanel.js */
     "This field is mandatory": "Ce champ est nécessaire",
+    "Load filters": "Charger les filtres",
+    "Save filters": "Enregistrer les filtres",
+    "Select filter encoding XML file": "Sélectionner le fichier XML de filtres",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Modifier la géométrie",
     "Edit geometrie": "Éditer la géométrie",

--- a/lib/Styler/lang/fr.js
+++ b/lib/Styler/lang/fr.js
@@ -10,6 +10,8 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
     "This field is mandatory": "Ce champ est nécessaire",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Modifier la géométrie",
+    "Edit geometrie": "Éditer la géométrie",
+    "Create buffer": "Créer une zone tampon",
     "Save this geometry": "Enregistrer cette géométrie",
     "spatialfilterpanel.geometry.saved": "Géométrie enregistrée sur ce navigateur.",
     /* FilterBuilder.js */

--- a/lib/Styler/lang/fr.js
+++ b/lib/Styler/lang/fr.js
@@ -11,6 +11,7 @@ OpenLayers.Lang.fr = OpenLayers.Util.extend(OpenLayers.Lang.fr, {
     "Load filters": "Charger les filtres",
     "Save filters": "Enregistrer les filtres",
     "Select filter encoding XML file": "Sélectionner le fichier XML de filtres",
+    "Please check highlighted field": "Veuillez vérifier les champs en surbrillance",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Modifier la géométrie",
     "Edit geometrie": "Éditer la géométrie",

--- a/lib/Styler/lang/ru.js
+++ b/lib/Styler/lang/ru.js
@@ -10,7 +10,9 @@ OpenLayers.Lang.ru = OpenLayers.Util.extend(OpenLayers.Lang.ru, {
     "This field is mandatory": "Это поле является обязательным",
     /* SpatialFilterPanel.js */
     "Modify geometry": "Изменить геометрию",
+    "Edit geometrie": "Edit geometrie (ru)",
     "Save this geometry": "Сохранить эту геометрию",
+    "Create buffer": "Create buffer (ru)",
     "spatialfilterpanel.geometry.saved": "Геометрия будет сохранена на этом навигаторе",
     /* FilterBuilder.js */
     "any": "какой-нибудь из",

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -997,12 +997,17 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
      * {Boolean} True is save is successful
      */
     saveFilters: function() {
-        var filterFormat = new OpenLayers.Format.Filter.v2_0_0();
-        var xmlFormat = new OpenLayers.Format.XML();
-        var filterFormatted = filterFormat.write(this.filter);
-        var xmlString = xmlFormat.write(filterFormatted);
+        var filterFormat = new OpenLayers.Format.Filter.v2_0_0(),
+            xmlFormat = new OpenLayers.Format.XML();
+        OpenLayers.Request.POST({
+           url: GEOR.config.PATHNAME + "/ws/fe/",
+           data: xmlFormat.write(filterFormat.write(this.getFilter())),
+           success: function(response) {
+               var o = Ext.decode(response.responseText);
+               window.location.href = GEOR.config.PATHNAME + "/" + o.filepath;
+           }
+        });
      }
-
 });
 
 /**

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1023,18 +1023,20 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                     var fx = new OpenLayers.Format.XML(),
                         ff = new OpenLayers.Format.Filter.v2_0_0();
                     var loadedFilters = ff.readChildNodes(fx.read(filterString));
-                    filterBuilder.filters = loadedFilters;
+                    var clonedFilters = filterBuilder.cloneFilter(loadedFilters.filter);
+                    filterBuilder.filter.push(clonedFilters);
                 }
             });
         };
 
-        var win = new Ext.Window({
+        var win = Ext.apply(new Ext.Window({
+            xtype: 'window',
             title: OpenLayers.i18n("Upload filters..."),
             constrainHeader: true,
             layout: 'fit',
-            width: 650,
-            minWidth: 630,
-            height: 500,
+            width: 420,
+            minWidth: 360,
+            height: 200,
             closeAction: 'hide',
             modal: false,
             items: [
@@ -1071,13 +1073,15 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                                     url: GEOR.config.PATHNAME + "/ws/fe/",
                                     success: function(form, action) {
                                         var o = Ext.decode(action.response.responseText);
-                                        fetchAndRestoreFilter( GEOR.config.PATHNAME + "/" + o.filepath);
+                                        fetchAndRestoreFilter( GEOR.config.PATHNAME + "/" + o.filepath,
+                                            this.findParentByType('window').filterBuilder);
                                     },
                                     failure: function(form, action) {
                                         GEOR.util.errorDialog({
                                             msg: tr("Cannot load filters")
                                         });
                                     },
+                                    scope: this
                                 })
                             }
                         }
@@ -1092,7 +1096,7 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                     }
                 }
             ]
-        });
+        }), {filterBuilder: this});
         win.show();
      }
 });

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -67,6 +67,12 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
     allowGroups: true,
 
     /**
+     * Property: allowSaveFilter
+     * {Boolean} Show button to save and load filter
+     */
+    allowSaveFilter: false,
+
+    /**
      * Property: geometryTypes
      * {Array} List all possible geometry types to search  with.
      */
@@ -275,6 +281,21 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                 },
                 scope: this
             });
+        }
+        if(this.allowSaveFilter) {
+            bar.push({
+                text: OpenLayers.i18n("Save filters"),
+                iconCls: "savegeometry",
+                handler: this.saveFilters,
+                scope: this
+            });
+            bar.push({
+                text: OpenLayers.i18n("Load filters"),
+                iconCls: "add",
+                handler: function() {alert('Filter loaded!');},
+                scope: this
+            });
+
         }
         return bar;
     },
@@ -966,7 +987,21 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
             }
         }
         return type;
-    }
+    },
+
+    /**
+     * Method: saveFilters
+     * Save filter to file
+     *
+     * Returns:
+     * {Boolean} True is save is successful
+     */
+    saveFilters: function() {
+        var filterFormat = new OpenLayers.Format.Filter.v2_0_0();
+        var xmlFormat = new OpenLayers.Format.XML();
+        var filterFormatted = filterFormat.write(this.filter);
+        var xmlString = xmlFormat.write(filterFormatted);
+     }
 
 });
 

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -292,7 +292,7 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
             bar.push({
                 text: OpenLayers.i18n("Load filters"),
                 iconCls: "add",
-                handler: function() {alert('Filter loaded!');},
+                handler: this.loadFilters,
                 scope: this
             });
 
@@ -1007,6 +1007,93 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                window.location.href = GEOR.config.PATHNAME + "/" + o.filepath;
            }
         });
+     },
+
+    /**
+     * Method: loadFilters
+     * Load filters from local file
+     *
+     */
+    loadFilters: function() {
+        var fetchAndRestoreFilter = function (filterURI, filterBuilder) {
+            OpenLayers.Request.GET({
+                url:filterURI,
+                success: function(response) {
+                    var filterString = response.responseText;
+                    var fx = new OpenLayers.Format.XML(),
+                        ff = new OpenLayers.Format.Filter.v2_0_0();
+                    var loadedFilters = ff.readChildNodes(fx.read(filterString));
+                    filterBuilder.filters = loadedFilters;
+                }
+            });
+        };
+
+        var win = new Ext.Window({
+            title: OpenLayers.i18n("Upload filters..."),
+            constrainHeader: true,
+            layout: 'fit',
+            width: 650,
+            minWidth: 630,
+            height: 500,
+            closeAction: 'hide',
+            modal: false,
+            items: [
+                {
+                    xtype: 'form',
+                    region: "north",
+                    standardSubmit: false,
+                    fileUpload: true,
+                    bodyStyle: 'padding:10px',
+                    labelWidth: 60,
+                    height: 50,
+                    monitorValid: true,
+                    buttonAlign: 'right',
+                    items: [
+                        {
+                            xtype: 'label',
+                            text: tr("Select filter encoding XML file")
+                        },
+                        {
+                            xtype: 'textfield',
+                            inputType: 'file',
+                            name: 'file',
+                            labelSeparator: tr("labelSeparator"),
+                            fieldLabel: tr("File"),
+                            allowBlank: false,
+                            blankText: tr("The file is required.")
+                        },
+                    ],
+                    buttons: [
+                        {
+                            text: 'Load',
+                            handler: function () {
+                                this.findParentByType('form').getForm().submit({
+                                    url: GEOR.config.PATHNAME + "/ws/fe/",
+                                    success: function(form, action) {
+                                        var o = Ext.decode(action.response.responseText);
+                                        fetchAndRestoreFilter( GEOR.config.PATHNAME + "/" + o.filepath);
+                                    },
+                                    failure: function(form, action) {
+                                        GEOR.util.errorDialog({
+                                            msg: tr("Cannot load filters")
+                                        });
+                                    },
+                                })
+                            }
+                        }
+                    ]
+                }
+            ],
+            buttons: [
+                {
+                    text: OpenLayers.i18n("Close"),
+                    handler: function() {
+                        win.hide();
+                    }
+                }
+            ]
+        });
+        win.show();
      }
 });
 

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1036,6 +1036,16 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                         ff = new OpenLayers.Format.Filter.v2_0_0();
                     var loadedFilters = ff.readChildNodes(fx.read(filterString));
                     var clonedFilters = filterBuilder.cloneFilter(loadedFilters.filter);
+                    if (clonedFilters.type == "&&") {
+                        filterBuilder.filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.ALL_OF);
+                        filterBuilder.changeBuilderType(Styler.FilterBuilder.ALL_OF);
+                    } else if (clonedFilters.type == "||") {
+                        filterBuilder.filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.ANY_OF);
+                        filterBuilder.changeBuilderType(Styler.FilterBuilder.ANY_OF);
+                    } else if (clonedFilters.type == "!") {
+                        filterBuilder.filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.NONE_OF);
+                        filterBuilder.changeBuilderType(Styler.FilterBuilder.NONE_OF);
+                    }
                     Ext.each(clonedFilters.filters, function(filter) {
                         if (filter instanceof OpenLayers.Filter.Spatial) {
                             var feature = new OpenLayers.Feature.Vector(

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -106,6 +106,11 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
     deactivable: false,
 
     /**
+     * Property: bufferSupport
+     */
+    bufferSupport: false,
+
+    /**
      * Property: toolbarType
      * {String} Place toolbar at the bottom with 'bbar' or
      *  at the 'top' with 'tbar'
@@ -678,6 +683,7 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
         var filter, type;
 
         var cfg = {
+            filterbuilder: this,
             customizeFilterOnInit: (conditionType === "group") && false,
             listeners: {
                 "change": function() {

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1082,8 +1082,10 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                     buttonAlign: 'right',
                     items: [
                         {
-                            xtype: 'label',
-                            text: tr("Select filter encoding XML file")
+                            xtype: 'panel',
+                            html: '<p>' + tr("Select filter encoding XML file") + '</p>',
+                            border: false,
+                            padding: 15
                         },
                         {
                             xtype: 'textfield',
@@ -1105,6 +1107,7 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                                         var o = Ext.decode(action.response.responseText);
                                         fetchAndRestoreFilter( GEOR.config.PATHNAME + "/" + o.filepath,
                                             this.findParentByType('window').filterBuilder);
+                                        this.findParentByType('window').close();
                                     },
                                     failure: function(form, action) {
                                         GEOR.util.errorDialog({

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1025,19 +1025,35 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
         var fetchAndRestoreFilter = function (filterURI, filterBuilder) {
             OpenLayers.Request.GET({
                 url:filterURI,
+                failure: function() {
+                    GEOR.util.errorDialog({
+                        msg: tr("Cannot access XML filters")
+                    });
+                },
                 success: function(response) {
                     var filterString = response.responseText;
                     var fx = new OpenLayers.Format.XML(),
                         ff = new OpenLayers.Format.Filter.v2_0_0();
                     var loadedFilters = ff.readChildNodes(fx.read(filterString));
                     var clonedFilters = filterBuilder.cloneFilter(loadedFilters.filter);
-                    Ext.each(clonedFilters.filters[0].filters, function(filter) {
-                        var feature = new OpenLayers.Feature.Vector(
-                            filter.value, {}, this.vectorLayer.style);
-                        this.vectorLayer.addFeatures([feature]);
-                        //this.addCondition('spatial', 
-                        //    this.vectorLayer.features[this.vectorLayer.features.length - 1], 
-                        //    filter);
+                    Ext.each(clonedFilters.filters, function(filter) {
+                        if (filter instanceof OpenLayers.Filter.Spatial) {
+                            var feature = new OpenLayers.Feature.Vector(
+                                filter.value, {}, this.vectorLayer.style);
+                            //Adding a feature to vectorLayer fire an addCondition
+                            //without the filter parameter
+                            //We manually remove the filter
+                            //and the row
+                            this.vectorLayer.addFeatures([feature]);
+                            this.childFiltersPanel.remove(
+                                this.childFiltersPanel.items.items[
+                                    this.childFiltersPanel.items.items.length-1
+                                    ].getId());
+                            this.filter.filters[0].filters.pop();
+                            this.addCondition("spatial", feature, filter);
+                        } else if (filter instanceof OpenLayers.Filter.Comparison) {
+                            this.addCondition("default", null, filter)
+                        }
                     }, filterBuilder);
                 }
             });
@@ -1092,7 +1108,7 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                                     },
                                     failure: function(form, action) {
                                         GEOR.util.errorDialog({
-                                            msg: tr("Cannot load filters")
+                                            msg: tr("Cannot upload XML filters")
                                         });
                                     },
                                     scope: this

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1101,21 +1101,28 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                         {
                             text: 'Load',
                             handler: function () {
-                                this.findParentByType('form').getForm().submit({
-                                    url: GEOR.config.PATHNAME + "/ws/fe/",
-                                    success: function(form, action) {
-                                        var o = Ext.decode(action.response.responseText);
-                                        fetchAndRestoreFilter( GEOR.config.PATHNAME + "/" + o.filepath,
-                                            this.findParentByType('window').filterBuilder);
-                                        this.findParentByType('window').close();
-                                    },
-                                    failure: function(form, action) {
-                                        GEOR.util.errorDialog({
-                                            msg: tr("Cannot upload XML filters")
+                                var form = this.findParentByType('form').getForm();
+                                if (form.isValid()) {
+                                    form.submit({
+                                        url: GEOR.config.PATHNAME + "/ws/fe/",
+                                        success: function(form, action) {
+                                            var o = Ext.decode(action.response.responseText);
+                                            fetchAndRestoreFilter( GEOR.config.PATHNAME + "/" + o.filepath,
+                                                this.findParentByType('window').filterBuilder);
+                                            this.findParentByType('window').close();
+                                        },
+                                        failure: function(form, action) {
+                                            GEOR.util.errorDialog({
+                                                msg: tr("Cannot upload XML filters")
+                                            });
+                                        },
+                                        scope: this
+                                    });
+                                } else {
+                                    GEOR.util.errorDialog({
+                                        msg: tr("Please check highlighted field")
                                         });
-                                    },
-                                    scope: this
-                                })
+                                }
                             }
                         }
                     ]

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -700,8 +700,9 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
      *     modifies the filter and adds a panel representing the new condition
      *     or group of conditions.
      */
-    addCondition: function(conditionType, feature) {
-        var filter, type;
+    addCondition: function(conditionType, feature, filter) {
+        filter = filter || null;
+        var type;
 
         var cfg = {
             filterbuilder: this,
@@ -722,7 +723,9 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
 
         switch (conditionType) {
         case "group":
-            filter = this.wrapFilter(this.createDefaultFilter());
+            if (!filter) {
+                filter = this.wrapFilter(this.createDefaultFilter());
+            }
             Ext.apply(cfg, {
                 xtype: "gx_filterbuilder",
                 filter: filter,
@@ -732,7 +735,9 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
             });
             break;
         case "spatial":
-            filter = this.createDefaultFilter(feature);
+            if (!filter) {
+                filter = this.createDefaultFilter(feature);
+            }
             Ext.apply(cfg, {
                 xtype: "gx_spatialfilterpanel",
                 filter: filter,
@@ -743,7 +748,9 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
             });
             break;
         default:
-            filter = this.createDefaultFilter();
+            if (!filter) {
+                filter = this.createDefaultFilter();
+            }
             Ext.apply(cfg, {
                 xtype: "gx_filterpanel",
                 filter: filter,
@@ -1024,7 +1031,14 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                         ff = new OpenLayers.Format.Filter.v2_0_0();
                     var loadedFilters = ff.readChildNodes(fx.read(filterString));
                     var clonedFilters = filterBuilder.cloneFilter(loadedFilters.filter);
-                    filterBuilder.filter.push(clonedFilters);
+                    Ext.each(clonedFilters.filters[0].filters, function(filter) {
+                        var feature = new OpenLayers.Feature.Vector(
+                            filter.value, {}, this.vectorLayer.style);
+                        this.vectorLayer.addFeatures([feature]);
+                        //this.addCondition('spatial', 
+                        //    this.vectorLayer.features[this.vectorLayer.features.length - 1], 
+                        //    filter);
+                    }, filterBuilder);
                 }
             });
         };

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1037,13 +1037,13 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
                     var loadedFilters = ff.readChildNodes(fx.read(filterString));
                     var clonedFilters = filterBuilder.cloneFilter(loadedFilters.filter);
                     if (clonedFilters.type == "&&") {
-                        filterBuilder.filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.ALL_OF);
+                        filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.ALL_OF);
                         filterBuilder.changeBuilderType(Styler.FilterBuilder.ALL_OF);
                     } else if (clonedFilters.type == "||") {
-                        filterBuilder.filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.ANY_OF);
+                        filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.ANY_OF);
                         filterBuilder.changeBuilderType(Styler.FilterBuilder.ANY_OF);
                     } else if (clonedFilters.type == "!") {
-                        filterBuilder.filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.NONE_OF);
+                        filterBuilder.findByType('combo')[0].setValue(Styler.FilterBuilder.NONE_OF);
                         filterBuilder.changeBuilderType(Styler.FilterBuilder.NONE_OF);
                     }
                     Ext.each(clonedFilters.filters, function(filter) {

--- a/lib/Styler/widgets/FilterBuilder.js
+++ b/lib/Styler/widgets/FilterBuilder.js
@@ -1004,6 +1004,9 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
      * {Boolean} True is save is successful
      */
     saveFilters: function() {
+        if (!this.allowSaveFilter) {
+            throw new Error('Call to saveFilters is not allowed when the property allowSaveFilter is set to false');
+        }
         var filterFormat = new OpenLayers.Format.Filter.v2_0_0(),
             xmlFormat = new OpenLayers.Format.XML();
         OpenLayers.Request.POST({
@@ -1022,6 +1025,9 @@ Styler.FilterBuilder = Ext.extend(Ext.Panel, {
      *
      */
     loadFilters: function() {
+        if (!this.allowSaveFilter) {
+            throw new Error('Call to loadFilters is not allowed when the property allowSaveFilter is set to false');
+        }
         var fetchAndRestoreFilter = function (filterURI, filterBuilder) {
             OpenLayers.Request.GET({
                 url:filterURI,

--- a/lib/Styler/widgets/SpatialFilterPanel.js
+++ b/lib/Styler/widgets/SpatialFilterPanel.js
@@ -143,41 +143,132 @@ Styler.SpatialFilterPanel = Ext.extend(Styler.BaseFilterPanel, {
 
         var buttonPanels = [{
             items: [{
-                xtype: "button",
+                xtype: "splitbutton",
                 iconCls: cls,
                 tooltip: OpenLayers.i18n("Modify geometry"),
                 enableToggle: true,
                 toggleGroup: this.toggleGroup,
-                listeners: {
-                    "toggle": function(btn, pressed) {
-                        var feature = this.feature;
-                        if (pressed) {
-                            var geometry = feature.geometry;
-                            if (geometry.CLASS_NAME === "OpenLayers.Geometry.Point") {
-                                this.map.setCenter(
-                                    geometry.getBounds().getCenterLonLat()
-                                );
-                            } else {
-                                this.map.zoomToExtent(
-                                    geometry.getBounds().scale(1.05)
-                                );
+                menu: {
+                    xtype: "menu",
+                    listeners: {
+                        "beforehide" : function() {
+                            var combo = this.findByType('combo')[0];
+                            if (combo) {
+                                return !(combo.view && combo.view.isVisible());
                             }
-                            // zindex hack (might need a rework of the handler feature 's
-                            // moveLayerToTop and moveLayerBack methods to manage this)
-                            zindex = feature.layer.getZIndex();
-                            this.mfControl.activate();
-                            this.mfControl.selectFeature(feature);
-                            feature.layer.setZIndex(this.map.Z_INDEX_BASE.Feature+1);
-                        } else {
-                            this.mfControl.unselectFeature(feature);
-                            this.mfControl.deactivate();
-                            feature.layer.setZIndex(zindex);
                         }
                     },
-                    scope: this
+                    items: [
+                        {
+                            xtype: "panel",
+                            border: false,
+                            bodyStyle : 'background:none',
+                            items:
+                           {
+                               xtype: "button",
+                               iconCls: cls,
+                               tooltip: OpenLayers.i18n("Edit geometry"),
+                               enableToggle: true,
+                               allowDepress: true,
+                               toggleGroup: this.toggleGroup,
+                               listeners: {
+                                   "toggle": function(btn, pressed) {
+                                       var feature = this.feature;
+                                       if (pressed) {
+                                           var geometry = feature.geometry;
+                                           if (geometry.CLASS_NAME === "OpenLayers.Geometry.Point") {
+                                               this.map.setCenter(
+                                                   geometry.getBounds().getCenterLonLat()
+                                               );
+                                           } else {
+                                               this.map.zoomToExtent(
+                                                   geometry.getBounds().scale(1.05)
+                                               );
+                                           }
+                                           // zindex hack (might need a rework of the handler feature 's
+                                           // moveLayerToTop and moveLayerBack methods to manage this)
+                                           zindex = feature.layer.getZIndex();
+                                           this.mfControl.activate();
+                                           this.mfControl.selectFeature(feature);
+                                           feature.layer.setZIndex(this.map.Z_INDEX_BASE.Feature+1);
+                                       } else {
+                                           this.mfControl.unselectFeature(feature);
+                                           this.mfControl.deactivate();
+                                           feature.layer.setZIndex(zindex);
+                                       }
+                                   },
+                                   scope: this
+                               }
+                           }
+                        }
+                    ]
                 }
             }]
         }];
+        if (this.filterbuilder.bufferSupport) {
+            var clickListener = function(btn) {
+                var feature = btn.findParentByType('gx_spatialfilterpanel').feature,
+                    bufferFeature = feature.clone();
+                var wkt = new OpenLayers.Format.WKT(),
+                    json = new OpenLayers.Format.JSON();
+                OpenLayers.Request.POST({
+                    url: GEOR.config.PATHNAME + "/ws/buffer/" +
+                          btn.findParentByType("panel").findByType("combo")[0].getValue(),
+                    data: wkt.extractGeometry(feature.geometry),
+                    success: function(response) {
+                        var bWkt = json.read(response.responseText)['geometry'];
+                        bufferFeature.geometry = wkt.read(bWkt).geometry;
+                        feature.layer.addFeatures([bufferFeature]);
+                    },
+                    scope: this
+                });
+                btn.findParentByType('menu').hide();
+                btn.toggle();
+            }
+
+            var bufferPanel = {
+                xtype: "panel",
+                border: false,
+                bodyStyle : 'background:none',
+                layout: "hbox",
+                width: 162,
+                items:
+                    [{
+                        xtype: "button",
+                        iconCls: "add",
+                        tooltip: OpenLayers.i18n("Create buffer"),
+                        enableToggle: false,
+                        toggleGroup: this.toggleGroup,
+                        listeners: {
+                            "click": clickListener
+                        }
+                    },
+                    {
+                        xtype: "combo",
+                        width: 140,
+                        typeAhead: true,
+                        triggerAction: 'all',
+                        autoSelect: true,
+                        emptyText: "Buffer size in meter",
+                        mode: 'local',
+                        store: {
+                            xtype: "arraystore",
+                            id: 0,
+                            fields: [
+                                'bufferSize',
+                                'displayText'
+                            ],
+                            data: [[10, '10 m'], [100, '100 m'], 
+                                [1000, '1 km'],[10000, '10 km']]
+                        },
+                        valueField: 'bufferSize',
+                        displayField: 'displayText'
+                    }
+                ]
+            };
+            var splitButton = buttonPanels[0].items[0];
+            splitButton.menu.items.push(bufferPanel);
+        }
 
         if (this.cookieProvider && OpenLayers.Format && OpenLayers.Format.WKT) {
             buttonPanels.push({
@@ -214,7 +305,7 @@ Styler.SpatialFilterPanel = Ext.extend(Styler.BaseFilterPanel, {
                     items: [this.comboConfig]
                 }]
             }, {
-                width: 70,
+                width: 90,
                 layout: 'column',
                 defaults: {
                     border: false,


### PR DESCRIPTION
We can save or load filters to/from XML files. Buttons are added to the filter builder toolbar to make this available.

![save_load_filters_screenshot](https://cloud.githubusercontent.com/assets/973241/14086098/65c7a5fa-f4f1-11e5-8e36-2893e3da371c.png)

The FilterBuilder widget has a new property `allowSaveFilter`. Value is set to false by default.

This feature require mapfishapp functionnalities.
